### PR TITLE
Specifies the connecting player in the RPC call to 'RPCA_OpenDoor' 

### DIFF
--- a/Virality/Patches/PlayerHandlerPatches.cs
+++ b/Virality/Patches/PlayerHandlerPatches.cs
@@ -27,7 +27,7 @@ internal static class PlayerHandlerPatches
             return;
 
         Virality.Logger?.LogDebug("Running open door RPC.");
-        SurfaceNetworkHandler.Instance.m_View.RPC("RPCA_OpenDoor", RpcTarget.OthersBuffered);
+        SurfaceNetworkHandler.Instance.m_View.RPC("RPCA_OpenDoor", player.refs.view.Controller);
 
         if (PhotonNetwork.IsMasterClient)
             CurrentObjectiveTracker.SendCurrentObjective();


### PR DESCRIPTION
Which prevents already connected players from receiving the call and re-opening the door.